### PR TITLE
feat: 원스토어 PNS 연동 및 환불 로직 구현

### DIFF
--- a/src/main/kotlin/com/ilgijjan/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/SecurityConfig.kt
@@ -35,6 +35,7 @@ class SecurityConfig(
                 it.requestMatchers(
                     "/api/auth/login", "api/auth/reissue",
                     "/api/music/**",
+                    "/billing/webhooks/**",
                     "/swagger-ui/**", "/v3/api-docs/**",
                     "/health"
                 ).permitAll()

--- a/src/main/kotlin/com/ilgijjan/domain/billing/application/PaymentHistoryReader.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/billing/application/PaymentHistoryReader.kt
@@ -14,4 +14,9 @@ class PaymentHistoryReader(
         return paymentHistoryRepository.findById(purchaseToken)
             .orElseThrow { CustomException(ErrorCode.PAYMENT_HISTORY_NOT_FOUND) }
     }
+
+    fun getByPurchaseTokenWithProduct(purchaseToken: String): PaymentHistory {
+        return paymentHistoryRepository.findByPurchaseTokenWithProduct(purchaseToken)
+            ?: throw CustomException(ErrorCode.PAYMENT_HISTORY_NOT_FOUND)
+    }
 }

--- a/src/main/kotlin/com/ilgijjan/domain/billing/application/UserWalletUpdater.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/billing/application/UserWalletUpdater.kt
@@ -12,4 +12,10 @@ class UserWalletUpdater(
         val wallet = userWalletReader.getByUserIdForUpdate(userId)
         wallet.charge(amount)
     }
+
+    @Transactional
+    fun revoke(userId: Long, amount: Int) {
+        val wallet = userWalletReader.getByUserIdForUpdate(userId)
+        wallet.revoke(amount)
+    }
 }

--- a/src/main/kotlin/com/ilgijjan/domain/billing/domain/PaymentHistory.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/billing/domain/PaymentHistory.kt
@@ -31,4 +31,8 @@ class PaymentHistory(
     fun consumeFail() {
         this.status = PaymentStatus.CONSUME_FAILED
     }
+
+    fun refund() {
+        this.status = PaymentStatus.REFUNDED
+    }
 }

--- a/src/main/kotlin/com/ilgijjan/domain/billing/domain/PaymentStatus.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/billing/domain/PaymentStatus.kt
@@ -3,5 +3,6 @@ package com.ilgijjan.domain.billing.domain
 enum class PaymentStatus {
     PENDING,
     COMPLETED,
-    CONSUME_FAILED
+    CONSUME_FAILED,
+    REFUNDED
 }

--- a/src/main/kotlin/com/ilgijjan/domain/billing/domain/StoreType.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/billing/domain/StoreType.kt
@@ -1,5 +1,13 @@
     package com.ilgijjan.domain.billing.domain
 
     enum class StoreType {
-        ONE_STORE, GOOGLE, APPLE
+        ONE_STORE, GOOGLE, APPLE;
+
+        companion object {
+            fun fromPath(path: String): StoreType? {
+                val formattedPath = path.uppercase().replace("-", "_")
+
+                return entries.find { it.name == formattedPath }
+            }
+        }
     }

--- a/src/main/kotlin/com/ilgijjan/domain/billing/domain/UserWallet.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/billing/domain/UserWallet.kt
@@ -16,4 +16,12 @@ class UserWallet(
         require(amount > 0) { "충전 수량은 0보다 커야 합니다." }
         this.noteBalance += amount
     }
+
+    fun revoke(amount: Int) {
+        require(amount > 0) { "회수 금액은 0보다 커야 합니다." }
+        require(this.noteBalance >= amount) {
+            "잔액이 부족하여 환불(회수) 처리를 할 수 없습니다. (userId: $userId, balance: $noteBalance, requested: $amount)"
+        }
+        this.noteBalance -= amount
+    }
 }

--- a/src/main/kotlin/com/ilgijjan/domain/billing/infrastructure/PaymentHistoryRepository.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/billing/infrastructure/PaymentHistoryRepository.kt
@@ -2,7 +2,17 @@ package com.ilgijjan.domain.billing.infrastructure
 
 import com.ilgijjan.domain.billing.domain.PaymentHistory
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
-interface PaymentHistoryRepository : JpaRepository<PaymentHistory, String>
+interface PaymentHistoryRepository : JpaRepository<PaymentHistory, String> {
+
+    @Query("""
+        select ph from PaymentHistory ph 
+        join fetch ph.storeProduct sp 
+        join fetch sp.product 
+        where ph.purchaseToken = :purchaseToken
+    """)
+    fun findByPurchaseTokenWithProduct(purchaseToken: String): PaymentHistory?
+}

--- a/src/main/kotlin/com/ilgijjan/integration/billing/application/BillingWebhookService.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/application/BillingWebhookService.kt
@@ -13,12 +13,12 @@ class BillingWebhookService(
 
     fun processWebhook(storePath: String, rawBody: String) {
         val type = StoreType.fromPath(storePath) ?: run {
-            log.warn("지원하지 않는 스토어 타입 요청입니다: {}", storePath)
-            throw IllegalArgumentException("Invalid store type: $storePath")
+            log.warn("[Webhook] 지원하지 않는 스토어 경로 요청 수신 (정상적인 호출인지 확인 필요): path={}", storePath)
+            return
         }
 
         val handler = handlers.find { it.getStoreType() == type } ?: run {
-            log.error("해당 스토어 타입을 처리할 핸들러가 없습니다: {}", type)
+            log.error("[Webhook Critical] {} 타입 핸들러가 등록되지 않았습니다. 즉시 핸들러 등록 코드를 확인하십시오.", type)
             throw IllegalStateException("No handler found for: $type")
         }
 

--- a/src/main/kotlin/com/ilgijjan/integration/billing/application/BillingWebhookService.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/application/BillingWebhookService.kt
@@ -1,0 +1,28 @@
+package com.ilgijjan.integration.billing.application
+
+import com.ilgijjan.domain.billing.domain.StoreType
+import com.ilgijjan.integration.billing.infrastructure.BillingWebhookHandler
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class BillingWebhookService(
+    private val handlers: List<BillingWebhookHandler>
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun processWebhook(storePath: String, rawBody: String) {
+        val type = StoreType.fromPath(storePath) ?: run {
+            log.warn("지원하지 않는 스토어 타입 요청입니다: {}", storePath)
+            throw IllegalArgumentException("Invalid store type: $storePath")
+        }
+
+        val handler = handlers.find { it.getStoreType() == type } ?: run {
+            log.error("해당 스토어 타입을 처리할 핸들러가 없습니다: {}", type)
+            throw IllegalStateException("No handler found for: $type")
+        }
+
+        log.info("Billing Webhook 처리 시작 - Store: {}, Body: {}", type, rawBody)
+        handler.handle(rawBody)
+    }
+}

--- a/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreSignatureVerifier.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreSignatureVerifier.kt
@@ -2,6 +2,7 @@ package com.ilgijjan.integration.billing.application
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.security.KeyFactory
@@ -14,13 +15,22 @@ class OneStoreSignatureVerifier(
     @Value("\${onestore.public-key}") private val publicKeyStr: String,
     private val objectMapper: ObjectMapper
 ) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
     companion object {
         private const val SIGNATURE_FIELD = "signature"
         private const val ALGORITHM_RSA = "RSA"
         private const val SIGNING_ALGORITHM = "SHA512withRSA"
     }
 
-    fun verify(rawBody: String, signature: String): Boolean {
+    fun validate(rawBody: String, signature: String) {
+        if (!verify(rawBody, signature)) {
+            log.error("[Webhook Critical] 원스토어 서명 검증 실패. Public Key 설정이 틀렸거나 Body 형식이 변경되었을 수 있습니다. 3일 내에 설정을 수정하지 않으면 데이터가 누락됩니다. Signature: {}, Body: {}", signature, rawBody)
+            throw IllegalStateException("Invalid OneStore Signature")
+        }
+    }
+
+    private fun verify(rawBody: String, signature: String): Boolean {
         val root = objectMapper.readTree(rawBody) as ObjectNode
         root.remove(SIGNATURE_FIELD)
 

--- a/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreSignatureVerifier.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreSignatureVerifier.kt
@@ -1,0 +1,37 @@
+package com.ilgijjan.integration.billing.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+
+@Component
+class OneStoreSignatureVerifier(
+    @Value("\${onestore.public-key}") private val publicKeyStr: String,
+    private val objectMapper: ObjectMapper
+) {
+    companion object {
+        private const val SIGNATURE_FIELD = "signature"
+        private const val ALGORITHM_RSA = "RSA"
+        private const val SIGNING_ALGORITHM = "SHA512withRSA"
+    }
+
+    fun verify(rawBody: String, signature: String): Boolean {
+        val root = objectMapper.readTree(rawBody) as ObjectNode
+        root.remove(SIGNATURE_FIELD)
+
+        val keyFactory = KeyFactory.getInstance(ALGORITHM_RSA)
+        val keySpec = X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyStr))
+        val publicKey = keyFactory.generatePublic(keySpec)
+
+        val sig = Signature.getInstance(SIGNING_ALGORITHM)
+        sig.initVerify(publicKey)
+        sig.update(root.toString().toByteArray(Charsets.UTF_8))
+
+        return sig.verify(Base64.getDecoder().decode(signature))
+    }
+}

--- a/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreWebhookHandler.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreWebhookHandler.kt
@@ -18,13 +18,17 @@ class OneStoreWebhookHandler(
 ) : BillingWebhookHandler {
     private val log = LoggerFactory.getLogger(javaClass)
 
+    companion object {
+        private const val PURCHASE_STATE_CANCELED = "CANCELED"
+    }
+
     override fun getStoreType(): StoreType = StoreType.ONE_STORE
 
     override fun handle(rawBody: String) {
         val request = objectMapper.readValue(rawBody, OneStorePnsRequest::class.java)
         oneStoreSignatureVerifier.validate(rawBody, request.signature)
 
-        if (request.purchaseState == "CANCELED") {
+        if (request.purchaseState == PURCHASE_STATE_CANCELED) {
             try {
                 billingTransactionHandler.refund(request.purchaseToken)
             } catch (e: CustomException) {

--- a/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreWebhookHandler.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreWebhookHandler.kt
@@ -1,10 +1,13 @@
 package com.ilgijjan.integration.billing.application
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.ilgijjan.common.exception.CustomException
+import com.ilgijjan.common.exception.ErrorCode
 import com.ilgijjan.domain.billing.application.BillingTransactionHandler
 import com.ilgijjan.domain.billing.domain.StoreType
 import com.ilgijjan.integration.billing.infrastructure.OneStorePnsRequest
 import com.ilgijjan.integration.billing.infrastructure.BillingWebhookHandler
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 @Component
@@ -13,16 +16,25 @@ class OneStoreWebhookHandler(
     private val billingTransactionHandler: BillingTransactionHandler,
     private val objectMapper: ObjectMapper
 ) : BillingWebhookHandler {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     override fun getStoreType(): StoreType = StoreType.ONE_STORE
 
     override fun handle(rawBody: String) {
         val request = objectMapper.readValue(rawBody, OneStorePnsRequest::class.java)
-
-        require(oneStoreSignatureVerifier.verify(rawBody, request.signature)) { "Invalid OneStore Signature" }
+        oneStoreSignatureVerifier.validate(rawBody, request.signature)
 
         if (request.purchaseState == "CANCELED") {
-            billingTransactionHandler.refund(request.purchaseToken)
+            try {
+                billingTransactionHandler.refund(request.purchaseToken)
+            } catch (e: CustomException) {
+                if (e.errorCode == ErrorCode.PAYMENT_HISTORY_NOT_FOUND) {
+                    log.warn("[Webhook Info] 원스토어 환불 처리를 중단합니다. DB에 결제 이력이 존재하지 않아 재시도해도 처리가 불가능합니다. token: {}", request.purchaseToken)
+                    return
+                }
+                log.error("[Webhook Retry] 환불 로직 실행 중 비즈니스 예외 발생. 재시도를 위해 에러를 전파합니다. message: {}", e.message)
+                throw e
+            }
         }
     }
 }

--- a/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreWebhookHandler.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/application/OneStoreWebhookHandler.kt
@@ -1,0 +1,28 @@
+package com.ilgijjan.integration.billing.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ilgijjan.domain.billing.application.BillingTransactionHandler
+import com.ilgijjan.domain.billing.domain.StoreType
+import com.ilgijjan.integration.billing.infrastructure.OneStorePnsRequest
+import com.ilgijjan.integration.billing.infrastructure.BillingWebhookHandler
+import org.springframework.stereotype.Component
+
+@Component
+class OneStoreWebhookHandler(
+    private val oneStoreSignatureVerifier: OneStoreSignatureVerifier,
+    private val billingTransactionHandler: BillingTransactionHandler,
+    private val objectMapper: ObjectMapper
+) : BillingWebhookHandler {
+
+    override fun getStoreType(): StoreType = StoreType.ONE_STORE
+
+    override fun handle(rawBody: String) {
+        val request = objectMapper.readValue(rawBody, OneStorePnsRequest::class.java)
+
+        require(oneStoreSignatureVerifier.verify(rawBody, request.signature)) { "Invalid OneStore Signature" }
+
+        if (request.purchaseState == "CANCELED") {
+            billingTransactionHandler.refund(request.purchaseToken)
+        }
+    }
+}

--- a/src/main/kotlin/com/ilgijjan/integration/billing/infrastructure/BillingWebhookController.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/infrastructure/BillingWebhookController.kt
@@ -1,8 +1,7 @@
 package com.ilgijjan.integration.billing.infrastructure
 
-import com.ilgijjan.domain.billing.domain.StoreType
+import com.ilgijjan.integration.billing.application.BillingWebhookService
 import io.swagger.v3.oas.annotations.Hidden
-import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -14,20 +13,14 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/billing/webhooks")
 class BillingWebhookController (
-    private val handlers: List<BillingWebhookHandler>
+    private val billingWebhookService: BillingWebhookService
 ) {
-    private val log = LoggerFactory.getLogger(javaClass)
-
     @PostMapping("/{storeType}")
     fun handleWebhook(
         @PathVariable storeType: String,
         @RequestBody rawBody: String
     ): ResponseEntity<Unit> {
-        val type = StoreType.fromPath(storeType) ?: return ResponseEntity.badRequest().build()
-        log.info("Billing Webhook 수신 - Store: {}, Body: {}", storeType, rawBody)
-        val handler = handlers.find { it.getStoreType() == type } ?: return ResponseEntity.badRequest().build()
-
-        handler.handle(rawBody)
+        billingWebhookService.processWebhook(storeType, rawBody)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/com/ilgijjan/integration/billing/infrastructure/BillingWebhookController.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/infrastructure/BillingWebhookController.kt
@@ -1,0 +1,33 @@
+package com.ilgijjan.integration.billing.infrastructure
+
+import com.ilgijjan.domain.billing.domain.StoreType
+import io.swagger.v3.oas.annotations.Hidden
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Hidden
+@RestController
+@RequestMapping("/billing/webhooks")
+class BillingWebhookController (
+    private val handlers: List<BillingWebhookHandler>
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostMapping("/{storeType}")
+    fun handleWebhook(
+        @PathVariable storeType: String,
+        @RequestBody rawBody: String
+    ): ResponseEntity<Unit> {
+        val type = StoreType.fromPath(storeType) ?: return ResponseEntity.badRequest().build()
+        log.info("Billing Webhook 수신 - Store: {}, Body: {}", storeType, rawBody)
+        val handler = handlers.find { it.getStoreType() == type } ?: return ResponseEntity.badRequest().build()
+
+        handler.handle(rawBody)
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/ilgijjan/integration/billing/infrastructure/BillingWebhookHandler.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/infrastructure/BillingWebhookHandler.kt
@@ -1,0 +1,8 @@
+package com.ilgijjan.integration.billing.infrastructure
+
+import com.ilgijjan.domain.billing.domain.StoreType
+
+interface BillingWebhookHandler {
+    fun getStoreType(): StoreType
+    fun handle(rawBody: String)
+}

--- a/src/main/kotlin/com/ilgijjan/integration/billing/infrastructure/OneStorePnsRequest.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/billing/infrastructure/OneStorePnsRequest.kt
@@ -1,0 +1,14 @@
+package com.ilgijjan.integration.billing.infrastructure
+
+data class OneStorePnsRequest(
+    val msgVersion: String,
+    val clientId: String,
+    val productId: String,
+    val messageType: String,
+    val purchaseId: String,
+    val developerPayload: String?,
+    val purchaseTimeMillis: Long,
+    val purchaseState: String,
+    val purchaseToken: String,
+    val signature: String
+)


### PR DESCRIPTION
## 🔥 Related Issues
- close #29 

## ✅ PR Point
- 재전송 정책 대응: 처리 실패(4xx, 500) 시 원스토어가 3일간 총 30회 재시도하므로, 서버 설정 오류 등 복구 가능한 에러는 예외를 던져 재전송을 유도하고, 결제 내역 미존재 등 처리가 불가능한 케이스는 정상 리턴하여 무의미한 재시도를 차단함.
- TODO
  - Callback URL 등록: 원스토어 콘솔에 `https://ilgijjan.store/billing/onestore` 등록 필요.
  - Public Key 설정: 서명 검증을 위해 콘솔에서 발급받은 라이선스 키를 `onestore.public-key` 설정값으로 등록 필요.

## 📚 Reference
- [07. PNS(Push Notification Service) 이용하기](https://onestore-dev.gitbook.io/dev/tools/billing/v21/pns#id-07.pns-pushnotificationservice-notification)