### PR TITLE
feat: Discord 알림 및 Grafana Alerting 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-**/resources/
+**/resources/**
+!**/resources/logback-spring.xml
 prometheus_data/
 grafana_data/
 logs/

--- a/src/main/kotlin/com/ilgijjan/common/log/DiscordAppender.kt
+++ b/src/main/kotlin/com/ilgijjan/common/log/DiscordAppender.kt
@@ -1,0 +1,89 @@
+package com.ilgijjan.common.log
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.spi.IThrowableProxy
+import ch.qos.logback.core.AppenderBase
+import com.ilgijjan.common.utils.DateFormatter
+import com.ilgijjan.common.utils.StringUtil
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.time.Instant
+
+class DiscordAppender : AppenderBase<ILoggingEvent>() {
+
+    var webhookUrl: String? = null
+    var enabled: Boolean = true
+    var applicationName: String = "ilgijjan"
+
+    override fun append(event: ILoggingEvent) {
+        if (!enabled || webhookUrl.isNullOrBlank()) {
+            return
+        }
+
+        try {
+            val message = buildDiscordMessage(event)
+            sendToDiscord(message)
+        } catch (e: Exception) {
+            addError("Failed to send Discord notification", e)
+        }
+    }
+
+    private fun buildDiscordMessage(event: ILoggingEvent): String {
+        val timestamp = DateFormatter.DATETIME_FORMATTER.format(Instant.ofEpochMilli(event.timeStamp))
+        val requestId = event.mdcPropertyMap["requestId"] ?: "no-id"
+        val userId = event.mdcPropertyMap["userId"] ?: "guest"
+        val loggerName = event.loggerName.substringAfterLast(".")
+        val message = event.formattedMessage.take(500)
+        val stackTrace = formatStackTrace(event.throwableProxy)
+
+        val embed = buildString {
+            append("""{"embeds":[{""")
+            append(""""title":"🚨 ERROR 발생","color":16711680,"fields":[""")
+
+            append("""{"name":"📌 환경","value":"${StringUtil.escapeJson(applicationName)}","inline":true},""")
+            append("""{"name":"⏰ 시간","value":"${StringUtil.escapeJson(timestamp)}","inline":true},""")
+            append("""{"name":"🆔 RequestId","value":"${StringUtil.escapeJson(requestId)}","inline":true},""")
+
+            append("""{"name":"👤 User","value":"${StringUtil.escapeJson(userId)}","inline":true},""")
+            append("""{"name":"📂 Logger","value":"${StringUtil.escapeJson(loggerName)}","inline":true},""")
+            append("""{"name":"\u200B","value":"\u200B","inline":true},""")
+
+            append("""{"name":"📝 메시지","value":"```${StringUtil.escapeJson(message)}```","inline":false}""")
+            if (stackTrace.isNotBlank()) {
+                append(""",{"name":"🔥 StackTrace","value":"```${StringUtil.escapeJson(stackTrace)}```","inline":false}""")
+            }
+            append("""]}]}""")
+        }
+
+        return embed
+    }
+
+    private fun formatStackTrace(throwableProxy: IThrowableProxy?): String {
+        if (throwableProxy == null) return ""
+
+        return buildString {
+            append("${throwableProxy.className}: ${throwableProxy.message}\n")
+            throwableProxy.stackTraceElementProxyArray
+                ?.take(5)
+                ?.forEach { append("  at ${it.steAsString}\n") }
+        }.take(800)
+    }
+
+    private fun sendToDiscord(jsonPayload: String) {
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create(webhookUrl!!))
+            .header("Content-Type", "application/json; charset=utf-8")
+            .POST(HttpRequest.BodyPublishers.ofString(jsonPayload, Charsets.UTF_8))
+            .timeout(Duration.ofSeconds(5))
+            .build()
+
+        httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+    }
+
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build()
+}

--- a/src/main/kotlin/com/ilgijjan/common/utils/DateFormatter.kt
+++ b/src/main/kotlin/com/ilgijjan/common/utils/DateFormatter.kt
@@ -1,7 +1,12 @@
 package com.ilgijjan.common.utils
 
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 object DateFormatter {
     val DOT_DATE_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+    val DATETIME_FORMATTER: DateTimeFormatter = DateTimeFormatter
+        .ofPattern("yyyy-MM-dd HH:mm:ss")
+        .withZone(ZoneId.of("Asia/Seoul"))
 }

--- a/src/main/kotlin/com/ilgijjan/common/utils/StringUtil.kt
+++ b/src/main/kotlin/com/ilgijjan/common/utils/StringUtil.kt
@@ -16,4 +16,13 @@ object StringUtil {
             "${result.groupValues[1]}*******${result.groupValues[4]}"
         }
     }
+
+    fun escapeJson(text: String): String {
+        return text
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+    }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Spring Boot 기본 설정 포함 -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- 환경변수에서 설정 읽기 -->
+    <springProperty scope="context" name="DISCORD_WEBHOOK_URL" source="discord.webhook.url" defaultValue=""/>
+    <springProperty scope="context" name="DISCORD_ENABLED" source="discord.webhook.enabled" defaultValue="false"/>
+
+    <!-- 프로파일별 로그 파일 경로 -->
+    <springProfile name="local">
+        <property name="LOG_FILE" value="./logs/spring.log"/>
+    </springProfile>
+    <springProfile name="prod">
+        <property name="LOG_FILE" value="/logs/spring.log"/>
+    </springProfile>
+
+    <!-- 콘솔 출력 패턴 -->
+    <property name="CONSOLE_LOG_PATTERN" value="%d{HH:mm:ss.SSS} %5p [%X{requestId:-no-id}] --- [%t] %-40.40logger{39} : %m%n"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} %5p [%X{requestId:-no-id}] --- [%t] %-40.40logger{39} : %m%n"/>
+
+    <!-- 콘솔 Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!-- 파일 Appender (롤링) -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>7</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <!-- Discord Appender -->
+    <appender name="DISCORD" class="com.ilgijjan.common.log.DiscordAppender">
+        <webhookUrl>${DISCORD_WEBHOOK_URL}</webhookUrl>
+        <enabled>${DISCORD_ENABLED}</enabled>
+        <applicationName>ilgijjan</applicationName>
+        <!-- ERROR 레벨만 전송 -->
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <!-- 비동기 Discord Appender (메인 스레드 블로킹 방지) -->
+    <appender name="ASYNC_DISCORD" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="DISCORD"/>
+        <queueSize>256</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <includeCallerData>true</includeCallerData>
+    </appender>
+
+    <!-- Root Logger -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="ASYNC_DISCORD"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Related Issues
- close #42 

## Summary
- ERROR 로그 발생 시 Discord로 상세 알림 전송 (DiscordAppender)
- Grafana Alerting으로 WARN 임계치, 서버 다운 알림 설정

## 변경 사항
- `DiscordAppender.kt`: Logback 커스텀 Appender로 ERROR 시 Discord 웹훅 호출
- `logback-spring.xml`: AsyncAppender로 비동기 처리
- `StringUtil.kt`: escapeJson() 추가
- `DateFormatter.kt`: DATETIME_FORMATTER 추가
- `application-prod.yml`: discord.webhook 설정 추가

## Grafana Alerting (모니터링 서버)
- WARN 임계치: `count_over_time({job="ilgijjan-logs"} |= "WARN" [1m]) > 20`
- 서버 다운: `up{job="spring-boot-app"} == 0`

## 역할 분담
| 알림 | 담당 |
|------|------|
| ERROR 상세 (스택트레이스) | DiscordAppender (앱) |
| WARN 임계치 | Grafana Alerting |
| 서버 다운 | Grafana Alerting |