### PR TITLE
infra: Terraform 구성 및 모니터링 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,10 @@ out/
 
 ### Kotlin ###
 .kotlin
+
+### Terraform ###
+**/.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+terraform/*.json

--- a/monitoring/CLAUDE.md
+++ b/monitoring/CLAUDE.md
@@ -1,0 +1,100 @@
+# Monitoring 구성 가이드
+
+## 개요
+
+모니터링은 별도 GCP VM(`ilgijjan-monitoring`)에서 Docker로 운영됩니다.
+이 폴더의 파일들은 **기록/복구용**이며, 실제 실행은 monitoring VM에서만 합니다.
+
+## 서버 정보
+
+| 항목 | 값 |
+|------|-----|
+| VM 이름 | ilgijjan-monitoring |
+| 리전 | asia-northeast3-a |
+| 머신 타입 | e2-small |
+| 도메인 | monitoring.ilgijjan.store |
+
+> IP 정보는 GCP 콘솔 또는 `terraform output`으로 확인하세요.
+
+## 구성 요소
+
+| 서비스 | 역할 | 포트 |
+|--------|------|------|
+| Grafana | 메트릭/로그 시각화 | 3000 |
+| Prometheus | 메트릭 수집 (prod VM actuator 스크랩) | 9090 |
+| Loki | 로그 수집 (Promtail에서 push) | 3100 |
+| nginx | 리버스 프록시 + HTTPS (Let's Encrypt) | 80, 443 |
+
+## 파일 설명
+
+```
+monitoring/
+├── CLAUDE.md            # 이 파일
+├── docker-compose.yml   # Grafana + Prometheus + Loki 구성
+├── prometheus.yml       # Prometheus 스크랩 설정 (prod VM 내부 IP: 10.10.0.2)
+├── loki-config.yml      # Loki 설정
+└── promtail-config.yml  # prod VM에 배치해야 하는 Promtail 설정
+```
+
+> ⚠️ `promtail-config.yml`은 **prod VM 홈 디렉토리**에 복사해야 합니다.
+> prod VM의 `docker-compose.yml`이 `./promtail-config.yml`로 참조합니다.
+
+## 초기 설치 순서 (서버 날아갔을 때 복구)
+
+### 1. Docker 설치
+```bash
+sudo apt update && sudo apt install -y ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update && sudo apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo usermod -aG docker $USER
+```
+
+### 2. 설정 파일 배치
+```bash
+mkdir -p ~/monitoring
+```
+
+아래 3개 파일을 monitoring VM의 `~/monitoring/` 에 내용 그대로 복사 붙여넣기 합니다.
+- `monitoring/docker-compose.yml` → `~/monitoring/docker-compose.yml`
+- `monitoring/prometheus.yml` → `~/monitoring/prometheus.yml` (`${PROD_VM_INTERNAL_IP}` → prod VM 내부 IP로 변경, GCP 콘솔에서 확인)
+- `monitoring/loki-config.yml` → `~/monitoring/loki-config.yml`
+
+그리고 `monitoring/promtail-config.yml`은 **prod VM 홈 디렉토리**에 복사합니다.
+- `monitoring/promtail-config.yml` → prod VM `~/promtail-config.yml` (`${MONITORING_VM_INTERNAL_IP}` → monitoring VM 내부 IP로 변경, GCP 콘솔에서 확인)
+
+### 3. 모니터링 스택 실행
+```bash
+cd ~/monitoring
+sudo docker compose up -d
+```
+
+### 4. nginx 설치 및 HTTPS 설정
+```bash
+sudo apt install -y nginx certbot python3-certbot-nginx
+sudo tee /etc/nginx/sites-available/monitoring > /dev/null << 'EOF'
+server {
+    listen 80;
+    server_name monitoring.ilgijjan.store;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+EOF
+sudo ln -s /etc/nginx/sites-available/monitoring /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+sudo certbot --nginx -d monitoring.ilgijjan.store --email {이메일} --agree-tos --non-interactive
+```
+
+## Grafana 초기 설정
+
+- 접속: https://monitoring.ilgijjan.store
+- 초기 계정: admin / admin (최초 접속 시 비밀번호 변경 권장)
+- Data Source 추가:
+  - Loki: `http://loki:3100`
+  - Prometheus: `http://prometheus:9090`

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "3"
+
+services:
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    networks:
+      - monitoring-net
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: always
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    networks:
+      - monitoring-net
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    restart: always
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yml:/etc/loki/loki-config.yml
+      - loki_data:/loki
+    command: -config.file=/etc/loki/loki-config.yml
+    networks:
+      - monitoring-net
+
+volumes:
+  grafana_data:
+  prometheus_data:
+  loki_data:
+
+networks:
+  monitoring-net:
+    driver: bridge

--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -1,0 +1,43 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+  chunk_idle_period: 5m
+  chunk_retain_period: 30s
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/boltdb-cache
+    shared_store: filesystem
+  filesystem:
+    directory: /loki/chunks
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0s
+
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'ilgijjan-server'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['${PROD_VM_INTERNAL_IP}:8080']

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://${MONITORING_VM_INTERNAL_IP}:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: ilgijjan-logs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: ilgijjan
+          __path__: /var/log/ilgijjan/*.log

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -1,0 +1,81 @@
+# ============================================================
+# 고정 외부 IP
+# ============================================================
+resource "google_compute_address" "prod" {
+  name   = "ilgijjan-prod-ip"
+  region = var.region
+}
+
+resource "google_compute_address" "monitoring" {
+  name   = "ilgijjan-monitoring-ip"
+  region = var.region
+}
+
+# ============================================================
+# prod VM — e2-standard-2 (2 vCPU, 8GB)
+# Spring Boot + Redis + RabbitMQ + Promtail + nginx
+# ============================================================
+resource "google_compute_instance" "prod" {
+  name         = "ilgijjan-prod"
+  machine_type = "e2-standard-2"
+  zone         = var.zone
+  tags         = ["ilgijjan-vm"]
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+      size  = 20
+      type  = "pd-ssd"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.main.id
+    access_config {
+      nat_ip = google_compute_address.prod.address
+    }
+  }
+
+  service_account {
+    email  = google_service_account.app.email
+    scopes = ["cloud-platform"]
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${var.ssh_public_key}"
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# ============================================================
+# monitoring VM — e2-small (2 vCPU 공유, 2GB)
+# Grafana + Loki + Prometheus + nginx
+# ============================================================
+resource "google_compute_instance" "monitoring" {
+  name         = "ilgijjan-monitoring"
+  machine_type = "e2-small"
+  zone         = var.zone
+  tags         = ["ilgijjan-vm", "ilgijjan-monitoring"]
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+      size  = 20
+      type  = "pd-ssd"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.main.id
+    access_config {
+      nat_ip = google_compute_address.monitoring.address
+    }
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${var.ssh_public_key}"
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -1,0 +1,42 @@
+ # ============================================================
+# Cloud SQL — MySQL 8.0, db-f1-micro, public IP
+# ============================================================
+resource "google_sql_database_instance" "main" {
+  name             = "ilgijjan-mysql"
+  database_version = "MYSQL_8_0"
+  region           = var.region
+
+  settings {
+    tier = "db-f1-micro"
+
+    ip_configuration {
+      ipv4_enabled = true
+      # DataGrip 등 외부 접속 시 아래 주석 해제 후 본인 IP 입력
+      # authorized_networks {
+      #   name  = "my-ip"
+      #   value = "YOUR_IP/32"
+      # }
+    }
+
+    backup_configuration {
+      enabled            = true
+      binary_log_enabled = true
+    }
+  }
+
+  # 실수로 terraform destroy 해도 DB는 삭제 안 됨
+  deletion_protection = true
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_sql_database" "app" {
+  name     = "ilgijjan"
+  instance = google_sql_database_instance.main.name
+}
+
+resource "google_sql_user" "app" {
+  name     = var.db_user
+  instance = google_sql_database_instance.main.name
+  password = var.db_password
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,17 @@
+# ============================================================
+# 앱용 서비스 계정
+# ============================================================
+resource "google_service_account" "app" {
+  account_id   = "ilgijjan-app"
+  display_name = "Ilgijjan App Service Account"
+}
+
+# GCS 읽기/쓰기
+resource "google_project_iam_member" "app_storage" {
+  project = var.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.app.email}"
+}
+
+# Vision, Gemini 등 나머지 API는 VM에 cloud-platform scope가 부여되어 있어
+# API 활성화만으로 충분히 호출 가능 (별도 IAM 불필요)

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,0 +1,87 @@
+# ============================================================
+# GCP API 활성화
+# ============================================================
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "compute.googleapis.com",
+    "sqladmin.googleapis.com",
+    "storage.googleapis.com",
+    "vision.googleapis.com",
+    "generativelanguage.googleapis.com",
+    "iam.googleapis.com",
+    "firebase.googleapis.com",
+  ])
+  service            = each.key
+  disable_on_destroy = false
+}
+
+# ============================================================
+# VPC & 서브넷
+# ============================================================
+resource "google_compute_network" "main" {
+  name                    = "ilgijjan-vpc"
+  auto_create_subnetworks = false
+  depends_on              = [google_project_service.apis]
+}
+
+resource "google_compute_subnetwork" "main" {
+  name          = "ilgijjan-subnet"
+  ip_cidr_range = "10.10.0.0/24"
+  network       = google_compute_network.main.id
+  region        = var.region
+}
+
+# ============================================================
+# 방화벽
+# ============================================================
+
+# SSH
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "ilgijjan-allow-ssh"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ilgijjan-vm"]
+}
+
+# HTTP / HTTPS
+resource "google_compute_firewall" "allow_http_https" {
+  name    = "ilgijjan-allow-http-https"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ilgijjan-vm"]
+}
+
+# Grafana(3000), Prometheus(9090), Loki(3100)
+resource "google_compute_firewall" "allow_monitoring" {
+  name    = "ilgijjan-allow-monitoring"
+  network = google_compute_network.main.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["3000", "9090", "3100"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["ilgijjan-monitoring"]
+}
+
+# 내부 통신 (prod → monitoring Loki 전송 등)
+resource "google_compute_firewall" "allow_internal" {
+  name    = "ilgijjan-allow-internal"
+  network = google_compute_network.main.name
+
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+
+  source_ranges = ["10.10.0.0/24"]
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,19 @@
+output "prod_ip" {
+  description = "prod VM 외부 IP → 가비아 A 레코드에 등록"
+  value       = google_compute_address.prod.address
+}
+
+output "monitoring_ip" {
+  description = "monitoring VM 외부 IP → 가비아 A 레코드에 등록"
+  value       = google_compute_address.monitoring.address
+}
+
+output "cloud_sql_ip" {
+  description = "Cloud SQL 공개 IP → 앱 환경변수 및 DataGrip 접속에 사용"
+  value       = google_sql_database_instance.main.public_ip_address
+}
+
+output "service_account_email" {
+  description = "앱 서비스 계정 이메일 → GCP 콘솔에서 키 발급 후 앱에 적용"
+  value       = google_service_account.app.email
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  # tfstate를 GCS에 원격 저장 (terraform init 전에 버킷 수동 생성 필요)
+  backend "gcs" {
+    bucket = "ilgijjan-tfstate"
+    prefix = "terraform/state"
+  }
+}
+
+provider "google" {
+  project     = var.project_id
+  region      = var.region
+  zone        = var.zone
+  credentials = file(var.credentials_file)
+}

--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -1,0 +1,24 @@
+# ============================================================
+# GCS 버킷 — 이미지/음악 파일 저장
+# ============================================================
+resource "google_storage_bucket" "main" {
+  name          = var.bucket_name
+  location      = var.region
+  force_destroy = false
+
+  uniform_bucket_level_access = true
+
+  cors {
+    origin          = ["*"]
+    method          = ["GET", "HEAD"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+}
+
+# 버킷 내 파일 전체 공개 읽기 (이미지/음악 URL 직접 접근용)
+resource "google_storage_bucket_iam_member" "public_read" {
+  bucket = google_storage_bucket.main.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,5 @@
+project_id     = "your-gcp-project-id"
+bucket_name    = "ilgijjan-bucket"
+db_user        = "ilgijjan"
+db_password    = "your-secure-password"
+ssh_public_key = "ssh-rsa AAAA..."

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,44 @@
+variable "project_id" {
+  description = "GCP 프로젝트 ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP 리전"
+  type        = string
+  default     = "asia-northeast3"
+}
+
+variable "zone" {
+  description = "GCP 존"
+  type        = string
+  default     = "asia-northeast3-a"
+}
+
+variable "bucket_name" {
+  description = "GCS 버킷 이름 (전 세계 유일해야 함)"
+  type        = string
+  default     = "ilgijjan-bucket"
+}
+
+variable "db_user" {
+  description = "Cloud SQL 사용자 이름"
+  type        = string
+  default     = "ilgijjan"
+}
+
+variable "db_password" {
+  description = "Cloud SQL 사용자 비밀번호"
+  type        = string
+  sensitive   = true
+}
+
+variable "ssh_public_key" {
+  description = "VM에 등록할 SSH 공개키 (ssh-keygen으로 생성한 .pub 파일 내용)"
+  type        = string
+}
+
+variable "credentials_file" {
+  description = "Terraform 서비스 계정 JSON 키 파일 경로"
+  type        = string
+}


### PR DESCRIPTION
## 🔥 Related Issues
- close #49

## 💻 작업 내용
- [x] Terraform으로 GCP 인프라 코드화 (VPC, VM, Cloud SQL, GCS, IAM)
- [x] prod/monitoring VM 환경 구성 (Docker, nginx, HTTPS)
- [x] 모니터링 스택 구성 (Grafana, Loki, Prometheus)
- [x] GitHub Secrets 신규 GCP 계정으로 교체

## ✅ PR Point
- 기존 수동 구성을 Terraform으로 코드화하여 재현 가능한 인프라 구성
- monitoring/ 디렉토리에 복구 가이드(CLAUDE.md) 포함

## ☀️ 스크린샷 / GIF / 화면 녹화

## 😡 Trouble Shooting
- GCS 버킷명 충돌 → ilgijjan-490801-bucket으로 변경
- 가비아 네임서버가 구 GCP Cloud DNS로 설정되어 있어 SERVFAIL → 가비아 기본 네임서버로 변경
- Loki 최신 버전 schema v13 + tsdb 요구 → loki-config.yml 업데이트

## 📚 Reference