### PR TITLE
feat: 관리자 페이지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ out/
 ### Kotlin ###
 .kotlin
 
+docker-compose.local.yml
+
 ### Terraform ###
 **/.terraform/
 *.tfstate

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,12 @@ dependencies {
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // Thymeleaf
+    implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+
+    // OAuth2 Client
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
     // Spring Actuator
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 

--- a/src/main/kotlin/com/ilgijjan/common/config/AdminSecurityConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/AdminSecurityConfig.kt
@@ -1,0 +1,80 @@
+package com.ilgijjan.common.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import org.springframework.security.oauth2.core.OAuth2Error
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@Order(1)
+class AdminSecurityConfig(
+    @Value("\${admin.allowed-emails}") private val allowedEmailsRaw: String,
+    private val clientRegistrationRepository: ClientRegistrationRepository,
+) {
+
+    private val allowedEmails: Set<String> by lazy {
+        allowedEmailsRaw.split(",").map { it.trim() }.toSet()
+    }
+
+    @Bean
+    fun adminFilterChain(http: HttpSecurity): SecurityFilterChain {
+        val oauth2UserService = DefaultOAuth2UserService()
+
+        val authorizationRequestResolver = DefaultOAuth2AuthorizationRequestResolver(
+            clientRegistrationRepository,
+            "/admin/oauth2/authorization"
+        )
+        authorizationRequestResolver.setAuthorizationRequestCustomizer { customizer ->
+            customizer.additionalParameters { params -> params["prompt"] = "select_account" }
+        }
+
+        http
+            .securityMatcher("/admin/**")
+            .csrf { it.disable() }
+            .authorizeHttpRequests {
+                it.requestMatchers("/admin/login-error").permitAll()
+                it.anyRequest().authenticated()
+            }
+            .oauth2Login {
+                it.loginPage("/admin/oauth2/authorization/google")
+                it.authorizationEndpoint { auth ->
+                    auth.baseUri("/admin/oauth2/authorization")
+                    auth.authorizationRequestResolver(authorizationRequestResolver)
+                }
+                it.redirectionEndpoint { redirect ->
+                    redirect.baseUri("/admin/login/oauth2/code/*")
+                }
+                it.userInfoEndpoint { userInfo ->
+                    userInfo.userService { request ->
+                        val user = oauth2UserService.loadUser(request)
+                        val email = user.attributes["email"] as? String
+                            ?: throw OAuth2AuthenticationException(OAuth2Error("email_not_found"))
+                        if (email !in allowedEmails) {
+                            throw OAuth2AuthenticationException(OAuth2Error("access_denied"), "허용되지 않은 이메일: $email")
+                        }
+                        user
+                    }
+                }
+                it.defaultSuccessUrl("/admin", true)
+                it.failureUrl("/admin/login-error")
+            }
+            .logout {
+                it.logoutUrl("/admin/logout")
+                    .logoutSuccessUrl("/admin/oauth2/authorization/google")
+            }
+            .exceptionHandling {
+                it.authenticationEntryPoint { _, response, _ ->
+                    response.sendRedirect("/admin/oauth2/authorization/google")
+                }
+            }
+
+        return http.build()
+    }
+}

--- a/src/main/kotlin/com/ilgijjan/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/SecurityConfig.kt
@@ -7,6 +7,7 @@ import com.ilgijjan.common.jwt.JwtTokenProvider
 import com.ilgijjan.domain.auth.application.TokenManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@Order(2)
 class SecurityConfig(
     private val jwtTokenProvider: JwtTokenProvider,
     private val authenticationEntryPoint: JwtAuthenticationEntryPoint,
@@ -25,6 +27,7 @@ class SecurityConfig(
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
+            .securityMatcher("/api/**", "/billing/**", "/swagger-ui/**", "/v3/api-docs/**", "/actuator/**")
             .csrf { it.disable() }
             .formLogin { it.disable() }
             .httpBasic { it.disable() }

--- a/src/main/kotlin/com/ilgijjan/common/constants/LogConstants.kt
+++ b/src/main/kotlin/com/ilgijjan/common/constants/LogConstants.kt
@@ -8,6 +8,7 @@ object LogConstants {
         "/swagger-ui",
         "/v3/api-docs",
         "/error",
-        "/favicon.ico"
+        "/favicon.ico",
+        "/admin"
     )
 }

--- a/src/main/kotlin/com/ilgijjan/domain/admin/presentation/AdminController.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/admin/presentation/AdminController.kt
@@ -1,0 +1,62 @@
+package com.ilgijjan.domain.admin.presentation
+
+import com.ilgijjan.domain.user.application.UserReader
+import com.ilgijjan.domain.wallet.application.UserWalletReader
+import com.ilgijjan.domain.wallet.application.UserWalletUpdater
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+@Controller
+@RequestMapping("/admin")
+class AdminController(
+    private val userReader: UserReader,
+    private val userWalletUpdater: UserWalletUpdater,
+    private val userWalletReader: UserWalletReader,
+) {
+
+    @GetMapping
+    fun index(model: Model): String = "admin/index"
+
+    @GetMapping("/login-error")
+    fun loginError(): String = "admin/login-error"
+
+    @GetMapping("/search")
+    fun search(@RequestParam nickname: String, model: Model): String {
+        val user = userReader.findByName(nickname)
+        if (user == null) {
+            model.addAttribute("searchError", "닉네임 '$nickname'을 찾을 수 없습니다.")
+        } else {
+            val wallet = userWalletReader.getByUserId(user.id!!)
+            model.addAttribute("foundNickname", nickname)
+            model.addAttribute("currentNoteCount", wallet.noteCount)
+        }
+        model.addAttribute("searchedNickname", nickname)
+        return "admin/index"
+    }
+
+    @PostMapping("/charge")
+    fun charge(
+        @RequestParam nickname: String,
+        @RequestParam amount: Int,
+        redirectAttributes: RedirectAttributes,
+    ): String {
+        val user = userReader.findByName(nickname)
+        if (user == null) {
+            redirectAttributes.addFlashAttribute("error", "닉네임 '$nickname'을 찾을 수 없습니다.")
+            return "redirect:/admin"
+        }
+
+        userWalletUpdater.charge(user.id!!, amount)
+        val wallet = userWalletReader.getByUserId(user.id)
+        redirectAttributes.addFlashAttribute("success", "${nickname}님에게 ${amount}개 충전 완료. 현재 보유: ${wallet.noteCount}개")
+        val encodedNickname = URLEncoder.encode(nickname, StandardCharsets.UTF_8)
+        return "redirect:/admin/search?nickname=$encodedNickname"
+    }
+}

--- a/src/main/kotlin/com/ilgijjan/domain/user/application/UserReader.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/user/application/UserReader.kt
@@ -19,4 +19,8 @@ class UserReader(
     fun findByProviderId(provider: OauthProvider, providerId: String): User? {
         return userRepository.findByOauthInfoProviderAndOauthInfoProviderId(provider, providerId)
     }
+
+    fun findByName(name: String): User? {
+        return userRepository.findByName(name)
+    }
 }

--- a/src/main/kotlin/com/ilgijjan/domain/user/infrastructure/UserRepository.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/user/infrastructure/UserRepository.kt
@@ -10,6 +10,8 @@ interface UserRepository : JpaRepository<User, Long> {
 
     fun existsByNameAndIdNot(name: String, id: Long): Boolean
 
+    fun findByName(name: String): User?
+
     fun findByOauthInfoProviderAndOauthInfoProviderId(
         provider: OauthProvider,
         providerId: String


### PR DESCRIPTION
## 🔥 Related Issues
- close #53 

## 💻 작업 내용
- [x] Google OAuth2 로그인 + 이메일 화이트리스트 기반 접근 제한
- [x] 닉네임으로 유저 조회 및 음표 충전 기능 구현
- [x] Thymeleaf 기반 관리자 페이지 UI 구현
- [x] AdminSecurityConfig 분리 (SecurityConfig와 filter chain 분리)
- [x] 로그인 실패 시 alert 후 Google 로그인으로 리다이렉트

## ✅ PR Point
- Spring Security filter chain을 @Order로 분리해 /admin/** 는 JWT가 아닌 OAuth2로 인증
- SecurityConfig에 securityMatcher 추가로 /admin/** 가 JWT filter chain에 걸리지 않도록 처리

## 😡 Trouble Shooting
- SecurityConfig에 securityMatcher가 없어 /admin/charge POST 요청에 JwtAuthenticationEntryPoint가 개입해 403 반환 → securityMatcher 추가로 해결
- 한글 닉네임을 redirect URL에 그대로 사용해 Tomcat에서 IllegalArgumentException 발생 → URLEncoder로 인코딩하여 해결
- form POST 요청 시 ApiAccessLogFilter의 ReadableRequestWrapper가 inputStream을 소진해 파라미터 누락 → /admin을 로그 제외 경로에 추가하여 해결
