### PR TITLE
refactor: 조회 성능 최적화 (DB 인덱스 + Redis 캐싱)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docker-compose.local.yml
 *.tfstate.backup
 *.tfvars
 terraform/*.json
+
+### 성능 측정 자료 (issue #56) - 로컬 측정용, 커밋 제외 ###
+perf/

--- a/src/main/kotlin/com/ilgijjan/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/CacheConfig.kt
@@ -1,0 +1,49 @@
+package com.ilgijjan.common.config
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.ilgijjan.domain.diary.presentation.ReadPublicDiariesResponse
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.support.NoOpCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+    companion object {
+        // 공개 일기 피드 캐시 (issue #56) - 모든 사용자에게 동일한 공유 응답이라 캐싱 안전
+        const val PUBLIC_DIARIES_CACHE = "publicDiaries"
+    }
+
+    // app.cache.enabled=false 로 캐싱 비활성화 가능 (성능 측정 시 before/after 비교용)
+    @Bean
+    @ConditionalOnProperty(name = ["app.cache.enabled"], havingValue = "true", matchIfMissing = true)
+    fun cacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
+        // 공개 피드 응답은 단일 타입(ReadPublicDiariesResponse)이라 타입 지정 직렬화로 안정적으로 처리
+        val objectMapper = jacksonObjectMapper()
+        val valueSerializer = Jackson2JsonRedisSerializer(objectMapper, ReadPublicDiariesResponse::class.java)
+
+        val publicDiariesConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(10))   // 무효화 누락 대비 안전망 TTL
+            .disableCachingNullValues()
+            .serializeKeysWith(SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(SerializationPair.fromSerializer(valueSerializer))
+
+        return RedisCacheManager.builder(connectionFactory)
+            .withCacheConfiguration(PUBLIC_DIARIES_CACHE, publicDiariesConfig)
+            .build()
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = ["app.cache.enabled"], havingValue = "false")
+    fun noOpCacheManager(): CacheManager = NoOpCacheManager()
+}

--- a/src/main/kotlin/com/ilgijjan/domain/diary/application/DiaryService.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/diary/application/DiaryService.kt
@@ -1,6 +1,7 @@
 package com.ilgijjan.domain.diary.application
 
 import com.ilgijjan.common.annotation.CheckDiaryOwner
+import com.ilgijjan.common.config.CacheConfig
 import com.ilgijjan.common.config.RabbitMqConfig
 import com.ilgijjan.common.constants.WalletConstants
 import com.ilgijjan.domain.diary.presentation.CreateDiaryRequest
@@ -13,6 +14,8 @@ import com.ilgijjan.domain.like.application.LikeReader
 import com.ilgijjan.domain.user.application.UserReader
 import com.ilgijjan.domain.wallet.application.UserWalletUpdater
 import com.ilgijjan.integration.messaging.application.MessageProducer
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -75,6 +78,10 @@ class DiaryService(
         return ReadMyDiariesResponse.from(diaries)
     }
 
+    @Cacheable(
+        cacheNames = [CacheConfig.PUBLIC_DIARIES_CACHE],
+        key = "(#lastId ?: 0) + ':' + #size"
+    )
     fun getPublicDiaries(lastId: Long?, size: Int): ReadPublicDiariesResponse {
         val diariesSlice = diaryReader.findAllPublicWithSlice(lastId, size)
         return ReadPublicDiariesResponse.from(diariesSlice)
@@ -82,18 +89,21 @@ class DiaryService(
 
     @Transactional
     @CheckDiaryOwner
+    @CacheEvict(cacheNames = [CacheConfig.PUBLIC_DIARIES_CACHE], allEntries = true)
     fun publishDiary(diaryId: Long) {
         diaryUpdater.publish(diaryId)
     }
 
     @Transactional
     @CheckDiaryOwner
+    @CacheEvict(cacheNames = [CacheConfig.PUBLIC_DIARIES_CACHE], allEntries = true)
     fun unpublishDiary(diaryId: Long) {
         diaryUpdater.unpublish(diaryId)
     }
 
     @Transactional
     @CheckDiaryOwner
+    @CacheEvict(cacheNames = [CacheConfig.PUBLIC_DIARIES_CACHE], allEntries = true)
     fun deleteDiary(diaryId: Long) {
         diaryDeleter.delete(diaryId)
     }

--- a/src/main/kotlin/com/ilgijjan/domain/diary/domain/Diary.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/diary/domain/Diary.kt
@@ -8,6 +8,15 @@ import jakarta.persistence.*
 import org.hibernate.annotations.SQLRestriction
 
 @Entity
+@Table(
+    name = "diary",
+    indexes = [
+        // 월별 본인 일기 조회 (user_id 필터 + created_at 정렬) - issue #56
+        Index(name = "idx_diary_user_created", columnList = "user_id, created_at"),
+        // 공개 피드 커서 조회 (is_public 필터 + id 정렬) - issue #56
+        Index(name = "idx_diary_public_id", columnList = "is_public, id")
+    ]
+)
 @SQLRestriction("status <> 'DELETED'")
 class Diary (
     @Id


### PR DESCRIPTION
## 🔥 Related Issues
- close #56

## 💻 작업 내용
- [x] `diary` 복합 인덱스 2개 추가: `(user_id, created_at)`, `(is_public, id)`
- [x] 공개 일기 피드(`GET /api/diaries/public`) Redis 캐싱 적용 (`@Cacheable` / `@CacheEvict`)

## ✅ PR Point — 전후 성능 측정

> **측정 조건**
> - DB: MySQL 8.0, 측정용 `diary` **512,000건**(공개 40,866건), `ANALYZE TABLE`로 통계 갱신 / Redis(로컬)
> - 인덱스: `EXPLAIN ANALYZE`, 워밍업 후 중앙값
> - 캐싱: k6 v1.1.0, **동시 30명**, 페이지당 20건, 30초
> - ※ 아래 배수(≈n배)는 **위 조건 기준**이며, 데이터량·동시 접속 수에 따라 달라짐

### DB 인덱스 (`EXPLAIN ANALYZE`, 중앙값)
| 쿼리 | Before | After |
| --- | --- | --- |
| 월별 본인 일기 조회 | 1.33ms (1,023행 + 정렬) | **0.075ms** (46행, 정렬 제거) |
| 공개 피드 첫 페이지 | 0.289ms (219행) | **0.167ms** (20행) |

### Redis 캐싱 (k6: 30명 동시, 페이지당 20건, 30초)
| 지표 | 캐싱 OFF | 캐싱 ON |
| --- | --- | --- |
| 처리량 (RPS) | 0.88 건/s | **346 건/s** (≈393배) |
| p95 응답시간 | 47.6초 | **134ms** |
| 30초간 처리량 | 50건 | **10,410건** |

### 정리 (위 측정 조건 기준)
- 월별 일기 조회 응답시간을 1.33ms → 0.075ms로 약 18배 단축함 (검사 행 1,023→46, 정렬 제거)
- 공개 피드 처리량을 0.88 → 346 RPS로 약 393배 향상함
- 공개 피드 p95 응답시간을 47.6초 → 134ms로 단축함
