### PR TITLE
refactor: 일기 생성 처리량 개선 (RabbitMQ 컨슈머 동시성)

### DIFF
--- a/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
@@ -14,8 +14,8 @@ class AsyncConfig {
     @Bean(name = ["asyncExecutor"])
     fun asyncExecutor(): Executor {
         return ThreadPoolTaskExecutor().apply {
-            corePoolSize = 4
-            maxPoolSize = 8
+            corePoolSize = 8      // 컨슈머 동시성 증가 대응 (일기 1건당 음악+이미지 2개 비동기 작업)
+            maxPoolSize = 16
             queueCapacity = 100
             keepAliveSeconds = 30
             setThreadNamePrefix("AsyncThread-")

--- a/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
@@ -14,7 +14,7 @@ class AsyncConfig {
     @Bean(name = ["asyncExecutor"])
     fun asyncExecutor(): Executor {
         return ThreadPoolTaskExecutor().apply {
-            corePoolSize = 8      // 컨슈머 동시성 증가 대응 (일기 1건당 음악+이미지 2개 비동기 작업)
+            corePoolSize = 12     // 컨슈머 동시성 최대 6 × (음악+이미지 2개) = 12개 즉시 병렬 처리
             maxPoolSize = 16
             queueCapacity = 100
             keepAliveSeconds = 30

--- a/src/main/kotlin/com/ilgijjan/integration/messaging/infrastructure/RabbitDiaryMessageListener.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/messaging/infrastructure/RabbitDiaryMessageListener.kt
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component
 class RabbitDiaryMessageListener(
     private val eventPublisher: ApplicationEventPublisher
 ) {
-    @RabbitListener(queues = [RabbitMqConfig.DIARY_QUEUE])
+    @RabbitListener(queues = [RabbitMqConfig.DIARY_QUEUE], concurrency = "3-6")
     fun onMessage(diaryId: Long, @Header(name = "requestId", required = false) requestId: String?) {
         MDC.put("requestId", requestId ?: IdGenerator.generateTraceId())
 


### PR DESCRIPTION
## 🔥 Related Issues
- close #58

## 💻 작업 내용
- [x] `@RabbitListener` 컨슈머 동시성 설정 (`concurrency = "3-6"`): 동시 처리 1건 → 3~6건 병렬
- [x] `asyncExecutor` 스레드풀 상향 (`4/8` → `12/16`) — 컨슈머 동시성(최대 6) × (음악+이미지 2개) = 피크 12개 작업 즉시 병렬

> 기존: 컨슈머 1개 + 리스너가 음악 생성 콜백을 길게 블로킹 대기 → **시스템 전체에서 동시 1건만 처리**

## ✅ PR Point — 전후 성능 측정

> **측정 조건**: 컨슈머 동시성 효과만 격리 측정 (1건당 3초 작업 흉내, 메시지 20건 소진 시간 / `concurrency` 1·4 고정)
> ※ 처리량 배수는 작업 시간과 무관하므로 짧은 시간으로 측정하고, 실제 1건(~60초)은 비례 환산

### RabbitMQ 처리량 (메시지 20건 소진)
| 지표 | concurrency=1 | concurrency=4 |
| --- | --- | --- |
| 소진 시간 | 60.2초 | **15.1초** |
| 처리량 | 0.33 건/s | **1.33 건/s** |

### 정리 (위 측정 조건 기준)
- 컨슈머 동시성을 1 → 4로 올려 20건 소진 시간을 60.2초 → 15.1초로 약 4배 단축함
- 실제 1건 ~60초 기준 환산 시, 동시 20건 처리가 약 20분 → 5분에 해당함
- 배포 설정은 `concurrency = "3-6"`(부하 시 3→6 자동 확장)으로 적용함
