### PR TITLE
refactor: Virtual Thread 전환 + 이미지 생성 동기 처리

### DIFF
--- a/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
@@ -1,6 +1,5 @@
 package com.ilgijjan.common.config
 
-import com.ilgijjan.common.log.MdcTaskDecorator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableAsync

--- a/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
@@ -4,36 +4,18 @@ import com.ilgijjan.common.log.MdcTaskDecorator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableAsync
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 @EnableAsync(proxyTargetClass = true)
 @Configuration
 class AsyncConfig {
 
     @Bean(name = ["diaryTaskExecutor"])
-    fun diaryTaskExecutor(): Executor {
-        return ThreadPoolTaskExecutor().apply {
-            corePoolSize = 30    // 동시 처리할 일기 수 상한 (Gemini Rate Limit 기준)
-            maxPoolSize = 30
-            queueCapacity = 200
-            keepAliveSeconds = 30
-            setThreadNamePrefix("DiaryTask-")
-            setTaskDecorator(MdcTaskDecorator())
-            initialize()
-        }
-    }
+    fun diaryTaskExecutor(): Executor =
+        Executors.newVirtualThreadPerTaskExecutor()
 
     @Bean(name = ["asyncExecutor"])
-    fun asyncExecutor(): Executor {
-        return ThreadPoolTaskExecutor().apply {
-            corePoolSize = 60    // 동시 처리 일기(30) × 자식 작업 수(music 1 + image 1 = 2) = 60
-            maxPoolSize = 60
-            queueCapacity = 200
-            keepAliveSeconds = 30
-            setThreadNamePrefix("AsyncThread-")
-            setTaskDecorator(MdcTaskDecorator())
-            initialize()
-        }
-    }
+    fun asyncExecutor(): Executor =
+        Executors.newVirtualThreadPerTaskExecutor()
 }

--- a/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/ilgijjan/common/config/AsyncConfig.kt
@@ -1,10 +1,11 @@
 package com.ilgijjan.common.config
 
+import com.ilgijjan.common.log.MdcTaskDecorator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.SimpleAsyncTaskExecutor
 import org.springframework.scheduling.annotation.EnableAsync
 import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
 @EnableAsync(proxyTargetClass = true)
 @Configuration
@@ -12,9 +13,17 @@ class AsyncConfig {
 
     @Bean(name = ["diaryTaskExecutor"])
     fun diaryTaskExecutor(): Executor =
-        Executors.newVirtualThreadPerTaskExecutor()
+        SimpleAsyncTaskExecutor().apply {
+            setVirtualThreads(true)
+            setTaskDecorator(MdcTaskDecorator())
+            setThreadNamePrefix("DiaryTask-")
+        }
 
     @Bean(name = ["asyncExecutor"])
     fun asyncExecutor(): Executor =
-        Executors.newVirtualThreadPerTaskExecutor()
+        SimpleAsyncTaskExecutor().apply {
+            setVirtualThreads(true)
+            setTaskDecorator(MdcTaskDecorator())
+            setThreadNamePrefix("AsyncThread-")
+        }
 }

--- a/src/main/kotlin/com/ilgijjan/domain/diary/application/DiaryEventListener.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/diary/application/DiaryEventListener.kt
@@ -9,8 +9,7 @@ class DiaryEventListener(
     private val diaryTaskProcessor: DiaryTaskProcessor
 ) {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    fun
-            onDiaryCreated(event: DiaryCreatedEvent) {
+    fun onDiaryCreated(event: DiaryCreatedEvent) {
         diaryTaskProcessor.process(event.diaryId)
     }
 }

--- a/src/main/kotlin/com/ilgijjan/domain/diary/application/DiaryTaskProcessor.kt
+++ b/src/main/kotlin/com/ilgijjan/domain/diary/application/DiaryTaskProcessor.kt
@@ -55,10 +55,9 @@ class DiaryTaskProcessor(
             val refinedText = textRefiner.refineText(baseText)
 
             val musicFuture = musicGenerator.generateMusicAsync(refinedText)
-            val imageFuture = imageGenerator.generateImageAsync(refinedText, diary.weather)
+            val imageUrl = imageGenerator.generateImage(refinedText, diary.weather)
 
             val musicResult = musicFuture.get()
-            val imageUrl = imageFuture.get()
 
             val updateCommand = UpdateDiaryResultCommand.of(imageUrl, musicResult)
             diaryUpdater.updateResult(diaryId, updateCommand)

--- a/src/main/kotlin/com/ilgijjan/integration/image/application/ImageGenerator.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/image/application/ImageGenerator.kt
@@ -4,5 +4,6 @@ import com.ilgijjan.domain.diary.domain.Weather
 import java.util.concurrent.CompletableFuture
 
 interface ImageGenerator {
+    fun generateImage(text: String, weather: Weather): String
     fun generateImageAsync(text: String, weather: Weather): CompletableFuture<String>
 }

--- a/src/main/kotlin/com/ilgijjan/integration/image/infrastructure/GeminiImageGenerator.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/image/infrastructure/GeminiImageGenerator.kt
@@ -59,7 +59,7 @@ class GeminiImageGenerator(
         }
     }
 
-    fun generateImage(text: String, weather: Weather): String {
+    override fun generateImage(text: String, weather: Weather): String {
         val prompt = buildPrompt(text, weather)
 
         val safetySettings = listOf(

--- a/src/main/kotlin/com/ilgijjan/integration/image/infrastructure/ReplicateImageGenerator.kt
+++ b/src/main/kotlin/com/ilgijjan/integration/image/infrastructure/ReplicateImageGenerator.kt
@@ -47,7 +47,7 @@ class ReplicateImageGenerator(
         return CompletableFuture.completedFuture(imageUrl)
     }
 
-    fun generateImage(text: String, weather: Weather): String {
+    override fun generateImage(text: String, weather: Weather): String {
         val prompt = buildPrompt(text, weather)
 
         val requestBody = mapOf(


### PR DESCRIPTION
## 🔥 Related Issues
- close #64

## 💻 작업 내용
- [x] executor를 Virtual Thread로 전환 (`SimpleAsyncTaskExecutor.setVirtualThreads(true)`)
- [x] `-Djdk.tracePinnedThreads=full`로 Pinning 발생 여부 실측 확인
- [x] 이미지 생성을 DiaryTask 쓰레드에서 직접 처리하도록 변경
- [x] `MdcTaskDecorator` + 스레드 이름 prefix 적용으로 MDC 전파 복원

## ✅ PR Point

일기 생성 파이프라인은 전 구간이 I/O 작업이라 외부 API 응답 대기 중에도 쓰레드가 점유 상태로 묶인다. 쓰레드 수와 동시 처리 수가 1:1로 종속된 구조다.

**이미지 생성 동기 처리**

음악 요청을 먼저 걸어놓고 그 사이에 이미지를 DiaryTask 쓰레드에서 직접 처리. 총 처리 시간은 동일하고 AsyncThread 하나를 절감한다.

**Virtual Thread 전환**

I/O 대기 중 캐리어 쓰레드를 반납하므로 쓰레드 수에 관계없이 동시 처리가 가능해진다.

부하 테스트(VUS=1300) 결과:

| | 플랫폼 쓰레드 | Virtual Thread |
|---|---|---|
| 성공률 | 50% | **100%** |
| 평균 처리 시간 | 81,708ms | **29,913ms** |
| 최대 쓰레드 증가량 | +1998개 | **+195개** |
| OOM 발생 | 있음 | **없음** |

## 😡 Trouble Shooting

**Pinning 검증**

Virtual Thread는 `synchronized` 블록 안에서 I/O 대기 시 캐리어 쓰레드를 반납하지 못한다(Pinning). JPA/Hibernate 내부에 `synchronized`가 있어 DB 접근 시 발생할 수 있다.

일기 생성 파이프라인은 DB 접근이 파이프라인 맨 앞/끝에만 있고, 그 사이 외부 API 대기 구간과 겹치지 않아 위험이 낮다고 판단했다. `-Djdk.tracePinnedThreads=full` 옵션으로 실측한 결과 Pinning 미발생 확인.

**MDC 전파 누락**

`Executors.newVirtualThreadPerTaskExecutor()`는 Java 표준 API라 `TaskDecorator` 개념이 없어 MDC 전파가 불가능하다. `SimpleAsyncTaskExecutor.setVirtualThreads(true)`로 교체하면 Virtual Thread를 유지하면서 Spring의 `TaskDecorator` 인프라를 그대로 활용할 수 있다. 두 방식 모두 내부적으로 `Thread.ofVirtual()`로 Virtual Thread를 생성하며, 차이는 Spring이 태스크 실행 전에 decorator를 거치게 해주는 래핑 레이어의 유무다.

## 📚 Reference
- [카카오페이 Tech - 코루틴과 Virtual Thread 비교](https://tech.kakaopay.com/post/coroutine_virtual_thread_wayne/)