### PR TITLE
refactor: 인덱스 관리 Flyway 이관 및 조회 성능 측정

### DIFF
--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,6 +1,4 @@
--- V1: baseline 스키마 (순수)
--- 테이블 + PK + UNIQUE + FK(및 FK 필수 인덱스)만 포함.
--- FK 의존성 순서로 생성: users/product → diary/store_product → likes/payment_history → fcm_token/user_wallet
+-- baseline 스키마 (성능 인덱스 제외, FK 의존성 순서로 생성)
 
 CREATE TABLE `users` (
   `id` bigint NOT NULL AUTO_INCREMENT,
@@ -27,8 +25,6 @@ CREATE TABLE `product` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
--- diary: 성능 인덱스 제외(공개 피드/월별 복합은 V2, V3에서 추가).
--- user_id는 FK 제약만 선언 → MySQL이 FK용 인덱스를 자동 생성(이름=제약명). 명시적으로 KEY를 두지 않음.
 CREATE TABLE `diary` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `created_at` datetime(6) DEFAULT NULL,

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -27,7 +27,8 @@ CREATE TABLE `product` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
--- diary: 성능 인덱스 제외. user_id FK를 위한 plain 인덱스만 유지.
+-- diary: 성능 인덱스 제외(공개 피드/월별 복합은 V2, V3에서 추가).
+-- user_id는 FK 제약만 선언 → MySQL이 FK용 인덱스를 자동 생성(이름=제약명). 명시적으로 KEY를 두지 않음.
 CREATE TABLE `diary` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `created_at` datetime(6) DEFAULT NULL,
@@ -45,7 +46,6 @@ CREATE TABLE `diary` (
   `status` enum('PENDING','COMPLETED','FAILED','DELETED') NOT NULL,
   `type` enum('PHOTO','TEXT') DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `ix_diary_user_id` (`user_id`),
   CONSTRAINT `FK74rd0bn5raxejw2ukenelbdmt` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 

--- a/src/main/resources/db/migration/V2__add_public_feed_index.sql
+++ b/src/main/resources/db/migration/V2__add_public_feed_index.sql
@@ -1,0 +1,5 @@
+-- V2: 공개 피드 조회용 복합 인덱스
+-- 쿼리: WHERE is_public = TRUE ORDER BY id DESC LIMIT n  (커서 페이지네이션)
+-- (is_public 등가 필터) + (id 정렬)을 인덱스 하나로 커버. SELECT가 id면 커버링 인덱스로 동작.
+-- 측정: 공개 0.3% 저밀도에서 10,106행 스캔 → 20행 (docs/쿼리 최적화/02-개선 측정 로그.md)
+CREATE INDEX `idx_diary_public_id` ON `diary` (`is_public`, `id`);

--- a/src/main/resources/db/migration/V2__add_public_feed_index.sql
+++ b/src/main/resources/db/migration/V2__add_public_feed_index.sql
@@ -1,5 +1,4 @@
--- V2: 공개 피드 조회용 복합 인덱스
--- 쿼리: WHERE is_public = TRUE ORDER BY id DESC LIMIT n  (커서 페이지네이션)
--- (is_public 등가 필터) + (id 정렬)을 인덱스 하나로 커버. SELECT가 id면 커버링 인덱스로 동작.
--- 측정: 공개 0.3% 저밀도에서 10,106행 스캔 → 20행 (docs/쿼리 최적화/02-개선 측정 로그.md)
+-- 공개 피드 조회용 복합 인덱스
+-- is_public(등가 필터) + id(정렬/커서)를 하나로 커버
+-- 쿼리: WHERE is_public = TRUE [AND id < :lastId] ORDER BY id DESC
 CREATE INDEX `idx_diary_public_id` ON `diary` (`is_public`, `id`);

--- a/src/main/resources/db/migration/V3__add_monthly_index.sql
+++ b/src/main/resources/db/migration/V3__add_monthly_index.sql
@@ -1,0 +1,9 @@
+-- V3: 월별 내 일기 조회용 복합 인덱스
+-- 쿼리: WHERE user_id = ? AND created_at >= ? AND created_at < ? ORDER BY created_at DESC
+-- (user_id 등가) + (created_at 범위/정렬)을 한 인덱스로 커버 → filesort 제거.
+-- 복합의 맨 앞이 user_id라 FK 인덱스 역할도 겸함 → 기존 단일 idx_diary_user_id는 중복이 되므로 제거.
+--
+-- 측정 메모: user당 일기 ~100개인 현실 분포에선 실이득 미미(웜 0.21ms→0.035ms, 둘 다 sub-ms).
+-- filesort 제거·플랜 정리 목적 + 파워유저 대비 안전망으로 유지. (docs/쿼리 최적화/02-개선 측정 로그.md)
+CREATE INDEX `idx_diary_user_created` ON `diary` (`user_id`, `created_at`);
+DROP INDEX `idx_diary_user_id` ON `diary`;

--- a/src/main/resources/db/migration/V3__add_monthly_index.sql
+++ b/src/main/resources/db/migration/V3__add_monthly_index.sql
@@ -1,10 +1,4 @@
--- V3: 월별 내 일기 조회용 복합 인덱스
+-- 월별 조회용 복합 인덱스
+-- user_id(등가 필터) + created_at(범위/정렬)을 하나로 커버 → filesort 제거
 -- 쿼리: WHERE user_id = ? AND created_at >= ? AND created_at < ? ORDER BY created_at DESC
--- (user_id 등가) + (created_at 범위/정렬)을 한 인덱스로 커버 → filesort 제거.
---
--- 복합의 맨 앞이 user_id라 FK 인덱스 역할도 겸함. baseline에서 FK가 자동 생성했던
--- 인덱스는, 이 복합이 그 역할을 대신하게 되면 MySQL이 자동으로 제거한다(수동 DROP 불필요).
---
--- 측정 메모: user당 일기 ~100개인 현실 분포에선 실이득 미미(웜 0.21ms→0.035ms, 둘 다 sub-ms).
--- filesort 제거·플랜 정리 목적 + 파워유저 대비 안전망으로 유지. (docs/쿼리 최적화/02-개선 측정 로그.md)
 CREATE INDEX `idx_diary_user_created` ON `diary` (`user_id`, `created_at`);

--- a/src/main/resources/db/migration/V3__add_monthly_index.sql
+++ b/src/main/resources/db/migration/V3__add_monthly_index.sql
@@ -1,9 +1,10 @@
 -- V3: 월별 내 일기 조회용 복합 인덱스
 -- 쿼리: WHERE user_id = ? AND created_at >= ? AND created_at < ? ORDER BY created_at DESC
 -- (user_id 등가) + (created_at 범위/정렬)을 한 인덱스로 커버 → filesort 제거.
--- 복합의 맨 앞이 user_id라 FK 인덱스 역할도 겸함 → 기존 단일 idx_diary_user_id는 중복이 되므로 제거.
+--
+-- 복합의 맨 앞이 user_id라 FK 인덱스 역할도 겸함. baseline에서 FK가 자동 생성했던
+-- 인덱스는, 이 복합이 그 역할을 대신하게 되면 MySQL이 자동으로 제거한다(수동 DROP 불필요).
 --
 -- 측정 메모: user당 일기 ~100개인 현실 분포에선 실이득 미미(웜 0.21ms→0.035ms, 둘 다 sub-ms).
 -- filesort 제거·플랜 정리 목적 + 파워유저 대비 안전망으로 유지. (docs/쿼리 최적화/02-개선 측정 로그.md)
 CREATE INDEX `idx_diary_user_created` ON `diary` (`user_id`, `created_at`);
-DROP INDEX `idx_diary_user_id` ON `diary`;


### PR DESCRIPTION
## 🔥 Related Issues
- close #68

## 💻 작업 내용
- [x] Flyway 도입 (`flyway-core`, `flyway-mysql`), `ddl-auto: validate` 전환
- [x] 인덱스 관리를 엔티티 `@Table(indexes)` → Flyway 마이그레이션으로 이관
- [x] V1 baseline (성능 인덱스 제외한 순수 스키마)
- [x] V2 공개 피드 인덱스 `(is_public, id)`
- [x] V3 월별 조회 인덱스 `(user_id, created_at)`

## ✅ PR Point
- 스키마 변경(인덱스 포함)을 Flyway 버전 히스토리로 관리 → "무슨 인덱스를 왜 만들었는지"가 코드로 남음
- 기존 dev/prod는 `baseline-on-migrate`로 현재 상태를 V1로 도장 → 기존 데이터 안전, V2부터 적용
- FK 인덱스는 MySQL 자동 생성에 위임 (복합 인덱스 추가 시 자동 정리됨)
- 인덱스 효과 측정
  - 로컬에서 diary 50만 건(공개 0.3%)을 넣고 인덱스 적용 전후를 `EXPLAIN ANALYZE`로 측정했다.
  - 공개 피드 조회(`WHERE is_public = TRUE ORDER BY id DESC LIMIT 20`)
    - 인덱스 전에는 조건에 맞는 20건을 채우기 위해 10,106행을 스캔했고, 인덱스 적용 후에는 20행만 읽었다. 
    - 실행 시간은 약 2.03ms에서 0.022ms로 줄었다.
  - 월별 조회(`WHERE user_id = ? AND created_at 범위 ORDER BY created_at DESC`)
    - 인덱스 전에는 유저의 105행을 읽고 별도 정렬(filesort)했고, 인덱스 적용 후에는 해당 월 4행만 읽고 정렬 없이 처리했다. 
    - 실행 시간은 약 0.21ms에서 0.035ms로 줄었다.

## 😡 Trouble Shooting
- 인덱스 효과 측정 시 콜드/웜 캐시 차이로 수치 과장 → 웜 여러 회 측정으로 통제 

## 📚 Reference
- [데이터베이스 인덱스(Index) 최적화 방법](https://somaz.tistory.com/402)